### PR TITLE
[communicator] add `proxy_command` support to connection block

### DIFF
--- a/.changes/v1.12/ENHANCEMENTS-20250301-165740.yaml
+++ b/.changes/v1.12/ENHANCEMENTS-20250301-165740.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: You can now utilize an SSH proxy command with the `proxy_command` argument in `connection` blocks of resources.
+time: 2025-03-01T16:57:40.050317317Z
+custom:
+    Issue: "394"

--- a/internal/communicator/shared/shared.go
+++ b/internal/communicator/shared/shared.go
@@ -95,6 +95,10 @@ var ConnectionBlockSupersetSchema = &configschema.Block{
 			Type:     cty.String,
 			Optional: true,
 		},
+		"proxy_command": {
+			Type:     cty.String,
+			Optional: true,
+		},
 		"bastion_host": {
 			Type:     cty.String,
 			Optional: true,

--- a/internal/communicator/ssh/provisioner_test.go
+++ b/internal/communicator/ssh/provisioner_test.go
@@ -186,6 +186,32 @@ func TestProvisioner_connInfoProxy(t *testing.T) {
 	}
 }
 
+func TestProvisioner_connInfoProxyCommand(t *testing.T) {
+	v := cty.ObjectVal(map[string]cty.Value{
+		"type":          cty.StringVal("ssh"),
+		"user":          cty.StringVal("root"),
+		"password":      cty.StringVal("supersecret"),
+		"private_key":   cty.StringVal("someprivatekeycontents"),
+		"host":          cty.StringVal("example.com"),
+		"port":          cty.StringVal("22"),
+		"timeout":       cty.StringVal("30s"),
+		"proxy_command": cty.StringVal("ssh -W %h:%p bastion-host.example.com"),
+	})
+
+	conf, err := parseConnectionInfo(v)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if conf.Host != "example.com" {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	if conf.ProxyCommand != "ssh -W %h:%p bastion-host.example.com" {
+		t.Fatalf("bad: %v", conf)
+	}
+}
+
 func TestProvisioner_stringBastionPort(t *testing.T) {
 	v := cty.ObjectVal(map[string]cty.Value{
 		"type":         cty.StringVal("ssh"),
@@ -225,5 +251,36 @@ func TestProvisioner_invalidPortNumber(t *testing.T) {
 	}
 	if got, want := err.Error(), "value must be a whole number, between 0 and 65535 inclusive"; got != want {
 		t.Errorf("unexpected error\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestProvisioner_multipleConnectionMethods(t *testing.T) {
+	// Create a connection info with all three connection methods specified
+	v := cty.ObjectVal(map[string]cty.Value{
+		"type":          cty.StringVal("ssh"),
+		"user":          cty.StringVal("root"),
+		"password":      cty.StringVal("supersecret"),
+		"private_key":   cty.StringVal("someprivatekeycontents"),
+		"host":          cty.StringVal("example.com"),
+		"port":          cty.StringVal("22"),
+		"proxy_command": cty.StringVal("ssh -W %h:%p bastion-host.example.com"),
+		"proxy_host":    cty.StringVal("proxy.example.com"),
+		"bastion_host":  cty.StringVal("bastion.example.com"),
+	})
+
+	conf, err := parseConnectionInfo(v)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Verify all three connection methods are parsed correctly
+	if conf.ProxyCommand != "ssh -W %h:%p bastion-host.example.com" {
+		t.Fatalf("bad proxy_command: %v", conf.ProxyCommand)
+	}
+	if conf.ProxyHost != "proxy.example.com" {
+		t.Fatalf("bad proxy_host: %v", conf.ProxyHost)
+	}
+	if conf.BastionHost != "bastion.example.com" {
+		t.Fatalf("bad bastion_host: %v", conf.BastionHost)
 	}
 }

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -230,6 +230,10 @@ var connectionBlockSupersetSchema = &configschema.Block{
 			Type:     cty.String,
 			Optional: true,
 		},
+		"proxy_command": {
+			Type:     cty.String,
+			Optional: true,
+		},
 		"bastion_host": {
 			Type:     cty.String,
 			Optional: true,

--- a/website/docs/language/resources/provisioners/connection.mdx
+++ b/website/docs/language/resources/provisioners/connection.mdx
@@ -137,6 +137,34 @@ The `ssh` connection also supports the following fields to facilitate connection
 | `proxy_port` | The port to use connect to the proxy host. | |
 | `proxy_user_name` | The username to use connect to the private proxy host. This argument should be specified only if authentication is required for the HTTP Proxy server. | |
 | `proxy_user_password` | The password to use connect to the private proxy host. This argument should be specified only if authentication is required for the HTTP Proxy server. | |
+| `proxy_command` | A command to execute that will pipe stdin and stdout through to establish the connection. This is useful for connecting through custom networking setups. You can use `%h` and `%p` placeholders for the destination host and port. For example: `ssh -W %h:%p bastion-host.example.com`. | |
+
+-> **Note:** You should only specify one connection method at a time. If multiple connection methods are specified (proxy_command, proxy_host, bastion_host), Terraform will use them in the following order of precedence: proxy_command, proxy_host, bastion_host.
+
+### Example using proxy_command
+
+```hcl
+resource "aws_instance" "example" {
+  # ... instance configuration ...
+
+  # Use a provisioner with proxy_command
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Hello from the remote instance'",
+    ]
+
+    connection {
+      type        = "ssh"
+      user        = "ubuntu"
+      host        = self.private_ip
+      private_key = file("~/.ssh/id_rsa")
+
+      # Use a proxy command to connect to a proxy through nc
+      proxy_command = "nc -X connect -x proxy.example.com:8080 %h %p"
+    }
+  }
+}
+```
 
 ## How Provisioners Execute Remote Scripts
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

I have a Terraform use-case where I am using an [AWS EC2 Instance Connect Endpoint](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect-with-ec2-instance-connect-endpoint.html) to access instances in different AWS accounts that do not have direct network access from the network location in which Terraform runs so that SSH connections can be established for use on `remote-exec` provisioner blocks. AWS's [connection guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect-using-eice.html) offers a few different methods:

1. Using a pipe to `aws ec2-instance-connect open-tunnel` via an `ssh -o ProxyCommand=` argument.
1. Running `aws ec2-instance-connect open-tunnel --local-port` as a background process to be used as a TCP proxy.
1. Using `aws ec2-instance-connect ssh` to open an interactive ssh session.

Of these, using an out-of-the-box Terraform I attempted to get number 2 to work. It was hacky, using `terraform_data` with `local-exec` provisioners to control starting and stopping of the process in a detached tmux. I had some success with it but am running into issues with handling Terraform resource provisioners leaving the processes hanging. It would simply be much cleaner to implement the ability to use a ProxyCommand-like attribute on the Terraform ssh connections.

This PR implements a `proxy_command` attribute on the `connection` block that will pipe SSH communication through an exec'd process. This enables the ability to use `aws ec2-instance-connect` as described in number 1. No workarounds are then required to use Terraform with instances that are only reachable through EC2 Instance Connect or potentially any number of other proxy methods.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

- [X] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
